### PR TITLE
PSE-281: Custom Javascript not being loaded on Mercado theme

### DIFF
--- a/templates/header.html
+++ b/templates/header.html
@@ -149,6 +149,13 @@
 </style>
 {% endif %}
 
+<!-- Custom Javascript -->
+{% if theme.options.custom_styles.JavaScript %}
+  <script type="text/javascript">
+    {{ theme.options.custom_styles.JavaScript }}
+  </script>
+{% endif %}
+
 </head>
 
 <body class="current-{{current.slug}}">


### PR DESCRIPTION
This PR adds the code on the Custom Javascript editor to the header of the page.