### PR TITLE
PSE-10105: Make social media icons conditional on URL 

### DIFF
--- a/templates/footer.html
+++ b/templates/footer.html
@@ -61,9 +61,15 @@
             </li>
           {% endif %}
           <li class='footer-social-menu'>
-            <a href="{{account.services.instagram.url}}" target="_blank" class='social-email'><img src="{{ static('img/instagram.png') }}" alt="Email Icon"></a>
-            <a href="{{account.services.facebook.url}}" target="_blank" class='social-fb'><img src="{{ static('img/Facebook.png') }}" alt="Facebook Icon"></a>
-            <a href="{{account.services.twitter.url}}" target="_blank" class='social-twitter'><img src="{{ static('img/Twitter.png') }}" alt="Twitter Icon"></a>
+            {% if account.services.instagram.url %}
+              <a href="{{account.services.instagram.url}}" target="_blank" class='social-email'><img src="{{ static('img/instagram.png') }}" alt="Email Icon"></a>
+            {% endif %}
+            {% if account.services.facebook.url %}
+              <a href="{{account.services.facebook.url}}" target="_blank" class='social-email'><img src="{{ static('img/instagram.png') }}" alt="Email Icon"></a>
+            {% endif %}
+            {% if account.services.twitter.url %}
+              <a href="{{account.services.twitter.url}}" target="_blank" class='social-email'><img src="{{ static('img/instagram.png') }}" alt="Email Icon"></a>
+            {% endif %}
           </li>
         </ul>
       </nav><!-- .footer-navigation -->


### PR DESCRIPTION
This PR renders social media icons only if the URL exists in the account config. In the prod bug ticket, the customer pointed out that the Twitter icon still persists even after removing the link + integration.

[PSE-10105](https://getbentobox.atlassian.net/browse/PSE-10105)

[PSE-10105]: https://getbentobox.atlassian.net/browse/PSE-10105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ